### PR TITLE
Implementing dynamic discovery

### DIFF
--- a/modules/distribution/pom.xml
+++ b/modules/distribution/pom.xml
@@ -67,6 +67,22 @@
             <groupId>jline</groupId>
             <artifactId>jline</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.apache.axis</groupId>
+            <artifactId>axis</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>commons-discovery</groupId>
+            <artifactId>commons-discovery</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>javax.xml</groupId>
+            <artifactId>jaxrpc-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.axis</groupId>
+            <artifactId>axis-ant</artifactId>
+        </dependency>
     </dependencies>
 
     <build>

--- a/modules/distribution/src/main/assembly/bin.xml
+++ b/modules/distribution/src/main/assembly/bin.xml
@@ -301,6 +301,10 @@
                 <include>log4j:log4j:jar</include>
                 <include>org.wso2.securevault:org.wso2.securevault:jar</include>
                 <include>org.wso2.carbon:org.wso2.carbon.logging:jar</include>
+                <include>org.apache.axis:axis:jar</include>
+                <include>commons-discovery:commons-discovery:jar</include>
+                <include>javax.xml:jaxrpc-api:jar</include>
+                <include>org.apache.axis:axis-ant:jar</include>
             </includes>
         </dependencySet>
         <dependencySet>

--- a/pom.xml
+++ b/pom.xml
@@ -358,6 +358,26 @@
                 <version>${carbon.um.ws.version}</version>
                 <scope>test</scope>
             </dependency>
+            <dependency>
+                <groupId>org.apache.axis</groupId>
+                <artifactId>axis</artifactId>
+                <version>${org.apache.axis}</version>
+            </dependency>
+            <dependency>
+                <groupId>commons-discovery</groupId>
+                <artifactId>commons-discovery</artifactId>
+                <version>${commons.discovery}</version>
+            </dependency>
+            <dependency>
+                <groupId>javax.xml</groupId>
+                <artifactId>jaxrpc-api</artifactId>
+                <version>${jaxrpc.api}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.axis</groupId>
+                <artifactId>axis-ant</artifactId>
+                <version>${axis.ant}</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 
@@ -475,6 +495,10 @@
         <cipher.tool.version>1.0.0-wso2v3</cipher.tool.version>
         <mysql.connector.version>5.1.36</mysql.connector.version>
         <guava.version>19.0</guava.version>
+        <org.apache.axis>1.4</org.apache.axis>
+        <commons.discovery>0.2</commons.discovery>
+        <jaxrpc.api>1.1</jaxrpc.api>
+        <axis.ant>1.4</axis.ant>
     </properties>
 
     <build>


### PR DESCRIPTION
**Dynamic discovery of broker nodes in cluster project server side implementation.**

In MB, the user/developers having to manually list out the IPs in the connection URL could be difficult. The change of IPs of the broker nodes would require reconfiguring and restart the client applications connected to it. I am implementing a way to dynamically detection the MB nodes in the cluster and load balance through them.

I got the IP address(all network interfaces) and AMQP ports(with SSL) and store database at cluster startup. When node shutdown that details are removed from the database.
I wrote an admin [2] service to get those database details at the carbon business module.

In Andes client [1], I implemented a new initialContextFactory and inside that, I made an AMQP URL

[1] wso2/andes#741
[2] wso2/carbon-business-messaging#367