### PR TITLE
[MB-1741] Updated migration tool to make queue names all simple

### DIFF
--- a/modules/tools/migration/src/main/java/org/wso2/mb/migration/DBConnector.java
+++ b/modules/tools/migration/src/main/java/org/wso2/mb/migration/DBConnector.java
@@ -49,20 +49,54 @@ public class DBConnector {
     private static final String MB_BINDING = "MB_BINDING";
     private static final String MB_QUEUE = "MB_QUEUE";
     private static final String MB_EXCHANGE = "MB_EXCHANGE";
+    private static final String MB_QUEUE_MAPPING = "MB_QUEUE_MAPPING";
+    private static final String MB_SLOT_MESSAGE_ID = "MB_SLOT_MESSAGE_ID";
+    private static final String MB_SLOT = "MB_SLOT";
 
     /**
      * String constants representing table columns.
      */
     private static final String BINDING_DETAILS = "BINDING_DETAILS";
     private static final String QUEUE_NAME = "QUEUE_NAME";
+    private static final String QUEUE_DATA = "QUEUE_DATA";
     private static final String EXCHANGE_NAME = "EXCHANGE_NAME";
     private static final String EXCHANGE_DATA = "EXCHANGE_DATA";
+    private static final String SLOT_ID = "SLOT_ID";
+    private static final String STORAGE_QUEUE_NAME = "STORAGE_QUEUE_NAME";
+    private static final String ASSIGNED_QUEUE_NAME = "ASSIGNED_QUEUE_NAME";
 
     /**
      * Prepared statements to read, insert and update bindings and message routers.
      */
     private static final String GET_BINDINGS = "SELECT * FROM " + MB_BINDING;
     private static final String GET_QUEUES = "SELECT * FROM " + MB_QUEUE;
+    private static final String GET_QUEUE_MAPPINGS = "SELECT * FROM " + MB_QUEUE_MAPPING;
+    private static final String GET_MB_SLOT_MESSAGE_IDS = "SELECT * FROM " + MB_SLOT_MESSAGE_ID;
+    private static final String GET_SLOTS = "SELECT * FROM " + MB_SLOT;
+
+
+    /**
+     * Queries related to updating queues.
+     */
+    private static final String UPDATE_QUEUE = "UPDATE " + MB_QUEUE
+                                                + " SET " + QUEUE_NAME + " =?"
+                                                + " , " + QUEUE_DATA + " =?"
+                                                + " WHERE " + QUEUE_NAME + " =?";
+
+    private static final String DELETE_ALL_BINDINGS = "DELETE FROM " + MB_BINDING;
+
+    private static final String UPDATE_MB_QUEUE_MAPPING = "UPDATE " + MB_QUEUE_MAPPING
+                                                + " SET " + QUEUE_NAME + " =?"
+                                                + " WHERE " + QUEUE_NAME + " =?";
+
+    private static final String UPDATE_MB_SLOT_MESSAGE_ID = "UPDATE " + MB_SLOT_MESSAGE_ID
+                                                + " SET " + QUEUE_NAME + " =?"
+                                                + " WHERE " + QUEUE_NAME + " =?";
+
+    private static final String UPDATE_MB_SLOT = "UPDATE " + MB_SLOT
+                                                + " SET " + STORAGE_QUEUE_NAME + " =?"
+                                                + " , " + ASSIGNED_QUEUE_NAME + " =?"
+                                                + " WHERE " + SLOT_ID + " =?";
 
     private static final String UPDATE_BINDING = "UPDATE " + MB_BINDING
                                                  + " SET " + BINDING_DETAILS + " =?"
@@ -78,6 +112,7 @@ public class DBConnector {
                                                   + EXCHANGE_NAME + ", "
                                                   + EXCHANGE_DATA + ") "
                                                   + " VALUES (?,?)";
+
 
     DBConnector(Properties properties) {
         try {
@@ -224,6 +259,174 @@ public class DBConnector {
         } finally {
             conn.close();
         }
+    }
+
+    /**
+     * Make queue names of MB_QUEUE table all simple letters. Before that read and delete
+     * all entries in MB_BINDING to get rid of foreign key constraints. Then update
+     * MB_BINDING table as well with modified queue names.
+     *
+     * @throws SQLException in case of executing updates
+     */
+    void updateQueueNamesInQueuesAndBindings() throws SQLException {
+        getConnection();
+        try {
+            PreparedStatement getBindingsStatement = conn.prepareStatement(GET_BINDINGS);
+            ResultSet bindingsResultSet = getBindingsStatement.executeQuery();
+
+            //delete all bindings to get rid of constraints
+            PreparedStatement removeBindingsStatement = conn.prepareStatement(DELETE_ALL_BINDINGS);
+            removeBindingsStatement.executeUpdate();
+
+            updateQueueNamesInQueues();
+
+            while (bindingsResultSet.next()) {
+                String queueName = bindingsResultSet.getString(QUEUE_NAME);
+                String bindingData = bindingsResultSet.getString(BINDING_DETAILS);
+                if (queueNameHasCapitals(queueName)) {
+                    String newQueueName = queueName.toLowerCase();
+                    bindingData = bindingData.replaceAll(queueName, newQueueName);
+                    queueName = newQueueName;
+                }
+
+                PreparedStatement addBindingsStatement = conn.prepareStatement(INSERT_BINDING);
+                addBindingsStatement.setString(1, bindingsResultSet.getString(EXCHANGE_NAME));
+                addBindingsStatement.setString(2, queueName);
+                addBindingsStatement.setString(3, bindingData);
+
+                addBindingsStatement.executeUpdate();
+
+            }
+
+        } catch (SQLException e) {
+            e.printStackTrace();
+        } finally {
+            conn.close();
+        }
+    }
+
+    /**
+     * Make queue names of MB_QUEUE table all simple letters.
+     *
+     * @throws SQLException in case of executing update
+     */
+    private void updateQueueNamesInQueues() throws SQLException {
+
+        PreparedStatement preparedStatement = conn.prepareStatement(GET_QUEUES);
+        ResultSet resultSet = preparedStatement.executeQuery();
+        while (resultSet.next()) {
+            String queueName = resultSet.getString(QUEUE_NAME);
+            if (queueNameHasCapitals(queueName)) {
+                String newQueueName = queueName.toLowerCase();
+                String queueData = resultSet.getString(QUEUE_DATA);
+                String newQueueData = queueData.replaceAll(queueName, newQueueName);
+
+                PreparedStatement updateStatement = conn.prepareStatement(UPDATE_QUEUE);
+                updateStatement.setString(1, newQueueName);
+                updateStatement.setString(2, newQueueData);
+                updateStatement.setString(3, queueName);
+                updateStatement.executeUpdate();
+            }
+        }
+    }
+
+
+    /**
+     * Make all queue names in MB_SLOT table all simple
+     *
+     * @throws SQLException in case of executing update
+     */
+    void updateQueueNamesInSlots() throws SQLException {
+        getConnection();
+        try {
+            PreparedStatement preparedStatement = conn.prepareStatement(GET_SLOTS);
+            ResultSet resultSet = preparedStatement.executeQuery();
+            while (resultSet.next()) {
+                String queueName = resultSet.getString(STORAGE_QUEUE_NAME);
+                if(queueNameHasCapitals(queueName)) {
+                    String newQueueName = queueName.toLowerCase();
+
+                    PreparedStatement updateStatement = conn.prepareStatement(UPDATE_MB_SLOT);
+                    updateStatement.setString(1, newQueueName);
+                    updateStatement.setString(2, newQueueName);
+                    updateStatement.setString(3, resultSet.getString(SLOT_ID));
+                    updateStatement.executeUpdate();
+                }
+
+            }
+        } catch (SQLException e) {
+            e.printStackTrace();
+        } finally {
+            conn.close();
+        }
+    }
+
+    /**
+     * Make queue names in MB_QUEUE_MAPPING table all simple
+     *
+     * @throws SQLException in case of executing update
+     */
+    void updateQueueNamesInQueueMappings() throws SQLException {
+        getConnection();
+        try {
+            PreparedStatement preparedStatement = conn.prepareStatement(GET_QUEUE_MAPPINGS);
+            ResultSet resultSet = preparedStatement.executeQuery();
+            while (resultSet.next()) {
+                String queueName = resultSet.getString(QUEUE_NAME);
+                if(queueNameHasCapitals(queueName)) {
+                    String newQueueName = queueName.toLowerCase();
+
+                    PreparedStatement updateStatement = conn.prepareStatement(UPDATE_MB_QUEUE_MAPPING);
+                    updateStatement.setString(1, newQueueName);
+                    updateStatement.setString(2, queueName);
+                    updateStatement.executeUpdate();
+                }
+            }
+
+        } catch (SQLException e) {
+            e.printStackTrace();
+        } finally {
+            conn.close();
+        }
+    }
+
+    /**
+     * Make queue names in  MB_SLOT_MESSAGE_ID table all simple
+     *
+     * @throws SQLException in case of executing update
+     */
+    void updateQueueNamesInSlotMessageIds() throws SQLException {
+        getConnection();
+        try {
+            PreparedStatement preparedStatement = conn.prepareStatement(GET_MB_SLOT_MESSAGE_IDS);
+            ResultSet resultSet = preparedStatement.executeQuery();
+            while (resultSet.next()) {
+                String queueName = resultSet.getString(QUEUE_NAME);
+                if(queueNameHasCapitals(queueName)) {
+                    String newQueueName = queueName.toLowerCase();
+
+                    PreparedStatement updateStatement = conn.prepareStatement(UPDATE_MB_SLOT_MESSAGE_ID);
+                    updateStatement.setString(1, newQueueName);
+                    updateStatement.setString(2, queueName);
+                    updateStatement.executeUpdate();
+                }
+            }
+        } catch (SQLException e) {
+            e.printStackTrace();
+        } finally {
+            conn.close();
+        }
+    }
+
+
+    /**
+     * Check if string has any uppercase letter
+     *
+     * @param queueName Name of queue
+     * @return true if has any upper case letter
+     */
+    private boolean queueNameHasCapitals(String queueName) {
+        return !queueName.equals(queueName.toLowerCase());
     }
 }
 

--- a/modules/tools/migration/src/main/java/org/wso2/mb/migration/Main.java
+++ b/modules/tools/migration/src/main/java/org/wso2/mb/migration/Main.java
@@ -29,5 +29,9 @@ public class Main {
 
         //Modify bindings since the format of the binding details string is different in WSO2MB 3.1.0 and WSO2MB 3.2.0
         processor.modifyBindings();
+
+        //Modify data in multiple tables making queue name references all simple.
+        processor.makeQueueNamesAllSimple();
+
     }
 }

--- a/modules/tools/migration/src/main/java/org/wso2/mb/migration/Processor.java
+++ b/modules/tools/migration/src/main/java/org/wso2/mb/migration/Processor.java
@@ -122,4 +122,19 @@ public class Processor {
         }
         addDlcBindings();
     }
+
+    /**
+     * Read data of tables and modify data making all queue name references all simple.
+     */
+    void makeQueueNamesAllSimple() {
+        try {
+            connector.updateQueueNamesInQueuesAndBindings();
+            connector.updateQueueNamesInSlots();
+            connector.updateQueueNamesInQueueMappings();
+            connector.updateQueueNamesInSlotMessageIds();
+        } catch (Exception e) {
+            System.out.println("Error while making queue names simple in all places");
+            e.printStackTrace();
+        }
+    }
 }


### PR DESCRIPTION
In MB 3.2.0 queue names are all simple. During migration following tables are updated. 

1. MB_BINDING
2. MB_QUEUE
3. MB_QUEUE_MAPPING
4. MB_SLOT_MESSAGE_ID
5. MB_SLOT